### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/promote-rc-to-main.yml
+++ b/.github/workflows/promote-rc-to-main.yml
@@ -10,6 +10,8 @@ on:
 
 jobs:
   promote:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Potential fix for [https://github.com/jromie0924/plane-tracker-rgb-pi/security/code-scanning/1](https://github.com/jromie0924/plane-tracker-rgb-pi/security/code-scanning/1)

In general, the fix is to add an explicit `permissions` block to the workflow or to the specific job, granting only the scopes needed. This documents the required privileges and prevents the `GITHUB_TOKEN` from inheriting broader repository/organization defaults.

For this specific workflow, the `promote` job needs to push commits and tags to the repository, so it must have `contents: write`. It does not obviously need other scopes (like `issues`, `pull-requests`, etc.). The best minimal fix is to add a `permissions` block at the job level under `promote:`:

```yaml
jobs:
  promote:
    permissions:
      contents: write
    runs-on: ubuntu-latest
    ...
```

This leaves all other jobs (if any are added later) unaffected unless they define their own permissions. To implement the change, edit `.github/workflows/promote-rc-to-main.yml` and insert the `permissions` mapping directly under the `promote:` job key, keeping indentation consistent (two spaces under `jobs:`, four under `promote:`).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
