### PR TITLE
remove abacus international entry

### DIFF
--- a/src/app_data/airlines.json
+++ b/src/app_data/airlines.json
@@ -130,16 +130,6 @@
     "active": "Y"
   },
   {
-    "id": "14",
-    "name": "Abacus International",
-    "alias": "\\N",
-    "iata": "1B",
-    "icao": "",
-    "callsign": "",
-    "country": "Singapore",
-    "active": "Y"
-  },
-  {
     "id": "15",
     "name": "Abelag Aviation",
     "alias": "\\N",


### PR DESCRIPTION
Callsign is an empty string, so any flight without a callsign will default to this, and it doesn't make any sense.